### PR TITLE
Remove two sides to "TABLEKEY" relationships types.

### DIFF
--- a/src/main/java/org/pdxfinder/validator/tablevalidation/errorCreators/BrokenRelationErrorCreator.java
+++ b/src/main/java/org/pdxfinder/validator/tablevalidation/errorCreators/BrokenRelationErrorCreator.java
@@ -167,7 +167,7 @@ public class BrokenRelationErrorCreator extends ErrorCreator {
       String orphanedColumnValues = StringUtils.join(orphanedColumnList, ", ");
       String description =
               String.format(
-                      "%s values in column %s of the %s table are not found in this column: %s",
+                      "%s values in this column are not found in column %s of the %s table: %s",
                       orphanTable.rowCount(),
                       child.column(),
                       child.table(),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,4 +4,4 @@ spring.servlet.multipart.enabled=true
 spring.servlet.multipart.location== /pdxfinder/validation/upload
 spring.main.banner-mode=off
 #Comment out the following line to enable log messages
-logging.level.root=OFF
+logging.level.root=


### PR DESCRIPTION
Because:
   - Currenlty one definition of table key is required between columns in the relationship. However, both should have the annotation to make it more readible in the yaml. This change allows for that.
   - Fix tests

 * TABLE_KEY_MANY_TO_ONE AND TABLE_KEY are the same